### PR TITLE
Install nccl in Dockerfile-x86_64

### DIFF
--- a/manylinux/.gitignore
+++ b/manylinux/.gitignore
@@ -1,0 +1,1 @@
+Dockerfile.tmp

--- a/manylinux/Dockerfile-x86_64
+++ b/manylinux/Dockerfile-x86_64
@@ -46,3 +46,5 @@ RUN LD_LIBRARY_PATH=/opt/_internal/cpython-2.7.11-ucs4/lib:${LD_LIBRARY_PATH} /o
 RUN wget -O /opt/swig-2.0.12.tar.gz https://sourceforge.net/projects/swig/files/swig/swig-2.0.12/swig-2.0.12.tar.gz/download && \
     cd /opt && tar xzf swig-2.0.12.tar.gz && cd /opt/swig-2.0.12 && ./configure && make && make install && cd /opt && rm swig-2.0.12.tar.gz
 
+RUN mkdir -p /src && cd /src && git clone https://github.com/NVIDIA/nccl.git nccl && cd nccl &&\
+    make -j `nproc` install <NCCL_MAKE_OPTS>  && cd .. && rm -rf nccl

--- a/manylinux/build_all.sh
+++ b/manylinux/build_all.sh
@@ -10,17 +10,17 @@ docker build -t ${REPO}/paddle_manylinux_devel:cuda7.5_cudnn5 -f Dockerfile.tmp 
 docker push ${REPO}/paddle_manylinux_devel:cuda7.5_cudnn5
 
 sed 's/<baseimg>/8.0-cudnn5-devel-centos6/g' Dockerfile-x86_64 | \
-sed 's/<NCCL_MAKE_OPTS>/NVCC_GENCODE="-gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_60,code=compute_60"/g'> Dockerfile.tmp
+sed 's/<NCCL_MAKE_OPTS>/NVCC_GENCODE="-gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_60,code=compute_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_62,code=sm_62"/g'> Dockerfile.tmp
 docker build -t ${REPO}/paddle_manylinux_devel:cuda8.0_cudnn5 -f Dockerfile.tmp .
 docker push ${REPO}/paddle_manylinux_devel:cuda8.0_cudnn5
 
 sed 's/<baseimg>/8.0-cudnn7-devel-centos6/g' Dockerfile-x86_64 | \
-sed 's/<NCCL_MAKE_OPTS>/NVCC_GENCODE="-gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_60,code=compute_60"/g'> Dockerfile.tmp
+sed 's/<NCCL_MAKE_OPTS>/NVCC_GENCODE="-gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_60,code=compute_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_62,code=sm_62"/g'> Dockerfile.tmp
 
 docker build -t ${REPO}/paddle_manylinux_devel:cuda8.0_cudnn7 -f Dockerfile.tmp .
 docker push ${REPO}/paddle_manylinux_devel:cuda8.0_cudnn7
 
 sed 's/<baseimg>/9.0-cudnn7-devel-centos6/g' Dockerfile-x86_64 | \
-sed 's/<NCCL_MAKE_OPTS>//g' > Dockerfile.tmp
+sed 's/<NCCL_MAKE_OPTS>/NVCC_GENCODE="-gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_60,code=compute_60 -gencode=arch=compute_61,code=sm_61 -gencode=arch=compute_62,code=sm_62 -gencode=arch=compute_70,code=sm_70"/g'> Dockerfile.tmp
 docker build -t ${REPO}/paddle_manylinux_devel:cuda9.0_cudnn7 -f Dockerfile.tmp .
 docker push ${REPO}/paddle_manylinux_devel:cuda9.0_cudnn7

--- a/manylinux/build_all.sh
+++ b/manylinux/build_all.sh
@@ -4,18 +4,23 @@ set -xe
 REPO="${REPO:-typhoon1986}"
 
 # NOTE: version matches are determined!
-sed 's/<baseimg>/7.5-cudnn5-devel-centos6/g' Dockerfile-x86_64 > Dockerfile.tmp
+sed 's/<baseimg>/7.5-cudnn5-devel-centos6/g' Dockerfile-x86_64 | \
+sed 's/<NCCL_MAKE_OPTS>/NVCC_GENCODE="-gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_52,code=sm_52"/g'> Dockerfile.tmp
 docker build -t ${REPO}/paddle_manylinux_devel:cuda7.5_cudnn5 -f Dockerfile.tmp .
 docker push ${REPO}/paddle_manylinux_devel:cuda7.5_cudnn5
 
-sed 's/<baseimg>/8.0-cudnn5-devel-centos6/g' Dockerfile-x86_64 > Dockerfile.tmp
+sed 's/<baseimg>/8.0-cudnn5-devel-centos6/g' Dockerfile-x86_64 | \
+sed 's/<NCCL_MAKE_OPTS>/NVCC_GENCODE="-gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_60,code=compute_60"/g'> Dockerfile.tmp
 docker build -t ${REPO}/paddle_manylinux_devel:cuda8.0_cudnn5 -f Dockerfile.tmp .
 docker push ${REPO}/paddle_manylinux_devel:cuda8.0_cudnn5
 
-sed 's/<baseimg>/8.0-cudnn7-devel-centos6/g' Dockerfile-x86_64 > Dockerfile.tmp
+sed 's/<baseimg>/8.0-cudnn7-devel-centos6/g' Dockerfile-x86_64 | \
+sed 's/<NCCL_MAKE_OPTS>/NVCC_GENCODE="-gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_60,code=compute_60"/g'> Dockerfile.tmp
+
 docker build -t ${REPO}/paddle_manylinux_devel:cuda8.0_cudnn7 -f Dockerfile.tmp .
 docker push ${REPO}/paddle_manylinux_devel:cuda8.0_cudnn7
 
-sed 's/<baseimg>/9.0-cudnn7-devel-centos6/g' Dockerfile-x86_64 > Dockerfile.tmp
+sed 's/<baseimg>/9.0-cudnn7-devel-centos6/g' Dockerfile-x86_64 | \
+sed 's/<NCCL_MAKE_OPTS>//g' > Dockerfile.tmp
 docker build -t ${REPO}/paddle_manylinux_devel:cuda9.0_cudnn7 -f Dockerfile.tmp .
 docker push ${REPO}/paddle_manylinux_devel:cuda9.0_cudnn7


### PR DESCRIPTION
Install nccl in Dockerfile, since we are using nccl to merge gradients.

NCCL is a part of CUDA toolkit, they will pack nccl in the next release of Docker image. We build and install it in our docker images for now and backward compatibility.

@qingqing01 Please check the `gen_code` settings. I am building these images now. However, to build them takes quite a long time. I am not sure `gen_code` settings are correct for nccl and CUDA toolkits.